### PR TITLE
feat(ui): added "Run this script" to the SourceCode context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ ndb .
 ```
 
 - Run any node command from within ndb's integrated terminal and ndb will connect automatically
+- Run any open script source by using 'Run this script' context menu item, ndb will connect automatically as well
 
 ## What can I do?
 

--- a/front_end/ndb/NdbMain.js
+++ b/front_end/ndb/NdbMain.js
@@ -64,6 +64,31 @@ Ndb.mainConfiguration = () => {
   };
 };
 
+/**
+ * @implements {UI.ContextMenu.Provider}
+ * @unrestricted
+ */
+Ndb.ContextMenuProvider = class {
+  /**
+   * @override
+   * @param {!Event} event
+   * @param {!UI.ContextMenu} contextMenu
+   * @param {!Object} object
+   */
+  appendApplicableItems(event, contextMenu, object) {
+    if (!object instanceof Workspace.UISourceCode)
+      return;
+    const url = object.url();
+    if (!url.startsWith('file://') || !url.endsWith('.js'))
+      return;
+    contextMenu.debugSection().appendItem(ls`Run this script`, async () => {
+      const platformPath = Common.ParsedURL.urlToPlatformPath(url, Host.isWin());
+      const processManager = await Ndb.NodeProcessManager.instance();
+      processManager.run(NdbProcessInfo.execPath, [platformPath]);
+    });
+  }
+};
+
 Ndb.ServiceManager = class {
   constructor() {
     this._runningServices = new Map();

--- a/front_end/ndb/module.json
+++ b/front_end/ndb/module.json
@@ -35,6 +35,13 @@
             "settingName": "blackboxAnythingOutsideCwd",
             "settingType": "boolean",
             "defaultValue": true
+        },
+        {
+            "type": "@UI.ContextMenu.Provider",
+            "contextTypes": [
+                "Workspace.UISourceCode"
+            ],
+            "className": "Ndb.ContextMenuProvider"
         }
     ],
     "dependencies": ["common", "sdk"],


### PR DESCRIPTION
This command will run `node ${script}`, ndb will automatically attach.