### PR TITLE
fix(startup): run pptr with --no-sandbox flag

### DIFF
--- a/ndb.js
+++ b/ndb.js
@@ -34,7 +34,8 @@ updateNotifier({pkg: require('./package.json')}).notify();
     userDataDir: await setupUserDataDir(configDir),
     args: [
       '--app=data:text/html,<style>html{background:#242424;}</style>',
-      '--enable-features=NetworkService'
+      '--enable-features=NetworkService',
+      '--no-sandbox'
     ]
   });
 


### PR DESCRIPTION
This flag may produce error at start on some Linux distributions.
At the same time we control what code is executed in browser and
expose some capabilities like way to run node process so
sandboxing is not as usefull as it is inside Chrome.

Fixes #13