### PR TITLE
fix(debugger,win): properly escape \ in paths for blackbox pattern

### DIFF
--- a/front_end/ndb/NdbMain.js
+++ b/front_end/ndb/NdbMain.js
@@ -28,7 +28,7 @@ Ndb.NdbMain = class extends Common.Object {
       const regexPatterns = Common.moduleSetting('skipStackFramesPattern').getAsArray()
           .filter(({pattern}) => !pattern.startsWith('^(?!(') && pattern !== `node_debug_demon[\\/]preload\\.js`);
       regexPatterns.push({pattern:
-          `^(?!(${NdbProcessInfo.cwd}|` +
+          `^(?!(${NdbProcessInfo.cwd.replace(/\\/g, '\\\\')}|` +
           `\\[eval\\]|` +
           `${Common.ParsedURL.platformPathToURL(NdbProcessInfo.cwd)}|` +
           `file:///\\[eval\\])).*\$`});


### PR DESCRIPTION
Fixes #21