### PR TITLE
fix(debug_frontend): improve frontend debugging experience

### DIFF
--- a/lib/file_system_backend.js
+++ b/lib/file_system_backend.js
@@ -31,8 +31,10 @@ class FileSystem {
       page.exposeFunction('registerFileSystem', this._registerFileSystem.bind(this)),
       page.exposeFunction('fileSystemGetEntry', this._fileSystemGetEntry.bind(this, (changed, added, removed) => {
         page.safeEvaluate((changed, added, removed) => {
-          if (self.InspectorFrontendAPI)
-            self.InspectorFrontendAPI.fileSystemFilesChangedAddedRemoved(changed, added, removed);
+          callFrontend(_ => {
+            if (self.InspectorFrontendAPI)
+              self.InspectorFrontendAPI.fileSystemFilesChangedAddedRemoved(changed, added, removed);
+          });
         }, changed, added, removed);
       })),
       page.exposeFunction('fileSystemDirectoryReaderReadEntries', this._fileSystemDirectoryReaderReadEntries.bind(this)),
@@ -41,9 +43,11 @@ class FileSystem {
       page.exposeFunction('fileSystemEntryMoveTo', this._fileSystemEntryMoveTo.bind(this)),
       page.exposeFunction('fileSystemEntryFile', this._fileSystemEntryFile.bind(this, (readerId, event, ...args) => {
         page.safeEvaluate(function(readerId, event, ...args) {
-          const reader = FileSystem._readers.get(readerId);
-          if (reader)
-            reader[`on${event}`](...args);
+          callFrontend(_ => {
+            const reader = FileSystem._readers.get(readerId);
+            if (reader)
+              reader[`on${event}`](...args);
+          });
         }, readerId, event, ...args);
       })),
       page.exposeFunction('fileSystemWriteFile', this._fileSystemWriteFile.bind(this)),

--- a/lib/search_backend.js
+++ b/lib/search_backend.js
@@ -214,7 +214,7 @@ class SearchBackend {
    */
   indexingTotalWorkCalculated(requestId, fileSystemPath, totalWork) {
     this._frontend.safeEvaluate((requestId, fileSystemPath, totalWork) => {
-      InspectorFrontendAPI.indexingTotalWorkCalculated(requestId, fileSystemPath, totalWork);
+      callFrontend(_ => InspectorFrontendAPI.indexingTotalWorkCalculated(requestId, fileSystemPath, totalWork));
     }, requestId, fileSystemPath, totalWork);
   }
 
@@ -225,7 +225,7 @@ class SearchBackend {
    */
   indexingWorked(requestId, fileSystemPath, worked) {
     this._frontend.safeEvaluate((requestId, fileSystemPath, worked) => {
-      InspectorFrontendAPI.indexingWorked(requestId, fileSystemPath, worked);
+      callFrontend(_ => InspectorFrontendAPI.indexingWorked(requestId, fileSystemPath, worked));
     }, requestId, fileSystemPath, worked);
   }
 
@@ -235,7 +235,7 @@ class SearchBackend {
    */
   indexingDone(requestId, fileSystemPath) {
     this._frontend.safeEvaluate((requestId, fileSystemPath) => {
-      InspectorFrontendAPI.indexingDone(requestId, fileSystemPath);
+      callFrontend(_ => InspectorFrontendAPI.indexingDone(requestId, fileSystemPath));
     }, requestId, fileSystemPath);
   }
 
@@ -246,7 +246,7 @@ class SearchBackend {
    */
   searchCompleted(requestId, fileSystemPath, files) {
     this._frontend.safeEvaluate((requestId, fileSystemPath, files) => {
-      InspectorFrontendAPI.searchCompleted(requestId, fileSystemPath, files);
+      callFrontend(_ => InspectorFrontendAPI.searchCompleted(requestId, fileSystemPath, files));
     }, requestId, fileSystemPath, files);
   }
 

--- a/ndb.js
+++ b/ndb.js
@@ -73,6 +73,9 @@ updateNotifier({pkg: require('./package.json')}).notify();
       serviceDir: path.join(__dirname, 'services'),
       repl: require.resolve('./lib/repl.js')
     })};`),
+    frontend.evaluateOnNewDocument(`function callFrontend(f) {
+      ${!!process.env.NDB_DEBUG_FRONTEND ? 'setTimeout(_ => f(), 0)' : 'f()'}
+    }`),
     frontend.setRequestInterception(true),
     frontend.exposeFunction('openInNewTab', url => require('opn')(url)),
     frontend.exposeFunction('copyText', text => require('clipboardy').write(text))

--- a/services/services.js
+++ b/services/services.js
@@ -18,9 +18,9 @@ class Services {
 
   static async create(frontend) {
     const services = new Services((serviceId, message) => {
-      frontend.safeEvaluate(function(serviceId, message) {
-        Ndb.serviceManager.notify(serviceId, message);
-      }, serviceId, message);
+      frontend.safeEvaluate(function(serviceId, message, isDebugFrontend) {
+        callFrontend(_ => Ndb.serviceManager.notify(serviceId, message));
+      }, serviceId, message, !!process.env.NDB_DEBUG_FRONTEND);
     });
     await Promise.all([
       frontend.exposeFunction('createNdbService', services.createNdbService.bind(services)),


### PR DESCRIPTION
When NDB_DEBUG_FRONTEND is set we should route each call to frontend
through setTimeout, otherwise as soon as we pause at breakpoint on
frontend side, all calls will be processed in incorrect order.