### PR TITLE
fix(deps): set puppeteer version to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "isbinaryfile": "^3.0.2",
     "mime": "^2.3.1",
     "opn": "^5.3.0",
-    "puppeteer": "^1.6.0",
+    "puppeteer": "1.6.0",
     "rimraf": "^2.6.2",
     "uglify-es": "^3.3.10",
     "update-notifier": "^2.5.0",


### PR DESCRIPTION
We use some undocumented capabilities that may become broken with next puppeteer release.