### PR TITLE
fix(cli): support --version and --help flags

### DIFF
--- a/ndb.js
+++ b/ndb.js
@@ -13,6 +13,30 @@ const os = require('os');
 const path = require('path');
 const {launch} = require('./lib/launcher.js');
 
+if (process.argv.length > 2 && (process.argv[2] === '-v' || process.argv[2] === '--version')) {
+  console.log(`v${require('./package.json').version}`);
+  process.exit(0);
+}
+
+if (process.argv.length > 2 && process.argv[2] === '--help') {
+  console.log('Usage:');
+  console.log('');
+  console.log('Use ndb instead of node command:');
+  console.log('\tndb server.js');
+  console.log('\tndb node server.js');
+  console.log('');
+  console.log('Prepend ndb in front of any other binary:');
+  console.log('\tndb npm run unit');
+  console.log('\tndb mocha');
+  console.log('\tndb npx mocha');
+  console.log('');
+  console.log('Launch ndb as a standalone application:');
+  console.log('\tndb .');
+  console.log('');
+  console.log('More information is available at https://github.com/GoogleChromeLabs/ndb#readme');
+  process.exit(0);
+}
+
 launch({
   configDir: path.join(os.homedir(), '.ndb'),
   argv: process.argv,


### PR DESCRIPTION
ndb dumpes version info and short help when run with corresponded
flag.

Fixes #17