### PR TITLE
feat(whitelist): add the way to whitelist node_module

### DIFF
--- a/front_end/ndb/module.json
+++ b/front_end/ndb/module.json
@@ -14,6 +14,12 @@
         },
         {
             "type": "setting",
+            "settingName": "whitelistedModules",
+            "settingType": "string",
+            "defaultValue": ""
+        },
+        {
+            "type": "setting",
             "category": "Debugger",
             "title": "Wait at end",
             "settingName": "waitAtEnd",

--- a/front_end/ndb_ui/NodeModulesBlackboxing.js
+++ b/front_end/ndb_ui/NodeModulesBlackboxing.js
@@ -1,0 +1,95 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * @implements {UI.ListWidget.Delegate}
+ */
+Ndb.NodeModulesBlackboxing = class extends UI.VBox {
+  constructor() {
+    super(true);
+    this.registerRequiredCSS('ndb_ui/nodeModulesBlackboxing.css');
+    
+    this.contentElement.createChild('div', 'header').textContent = ls`Node modules whitelist`;
+
+    this._items = new UI.ListModel();
+    this._list = new UI.ListControl(this._items, this, UI.ListMode.NonViewport);
+    this._list.element.classList.add('dependency-list');
+    this.contentElement.appendChild(this._list.element);
+
+    this._emptyPlaceholder = createElementWithClass('div', 'dependency-list-empty');
+    this._emptyPlaceholder.textContent = Common.UIString('No dependencies');
+
+    this.contentElement.tabIndex = 0;
+    this.contentElement.appendChild(this._emptyPlaceholder);
+
+    this._reloadButton = this.contentElement.appendChild(
+        UI.createTextButton(Common.UIString('Apply and reload'), _ => Components.reload(), 'reload-button'));
+    this._update();
+  }
+
+  async _update() {
+    const processManager = await Ndb.NodeProcessManager.instance();
+    const {error, code, stderror, stdout} = await processManager.run(NdbProcessInfo.npmExecPath, ['ls', '--depth=0', '--json']);
+    if (error || code !== 0 || stderror)
+      return;
+    let dependencies;
+    try {
+      dependencies = Object.keys(JSON.parse(stdout).dependencies);
+    } catch (e) {
+      return;
+    }
+    const whitelisted = new Set((Common.moduleSetting('whitelistedModules').get() || '').split(','));
+    this._items.replaceAll(dependencies.map(name => ({
+      name,
+      whitelisted: whitelisted.has(name)
+    })));
+    this._emptyPlaceholder.style.display = this._items.length > 0 ? 'none' : 'block';
+    this._list.element.style.display = this._items.length === 0 ? 'none' : 'block';
+    this._reloadButton.style.display = this._items.length === 0 ? 'none' : 'block';
+  }
+
+  /**
+   * @override
+   * @param {*} item
+   * @param {boolean} editable
+   * @return {!Element}
+   */
+  createElementForItem(item, editable) {
+    const element = createElementWithClass('div', 'dependency-list-item');
+    const title = element.createChild('div', 'dependency-title');
+    title.textContent = item.name;
+    title.title = item.name;
+    element.createChild('div', 'dependency-separator');
+
+    const select = /** @type {!HTMLSelectElement} */ (createElementWithClass('select', 'chrome-select'));
+    [ls`Blackbox`, ls`Whitelist`].forEach(value => {
+      const option = select.createChild('option');
+      option.value = value;
+      option.textContent = value;
+    });
+    select.selectedIndex = item.whitelisted ? 1 : 0;
+    select.addEventListener('change', this._updateItem.bind(this, select, item));
+    element.createChild('div', 'dependency-behavior').appendChild(select);
+    return element;
+  }
+
+  isItemSelectable(item) {
+    return false;
+  }
+
+  heightForItem(item) {
+  }
+
+  _updateItem(select, item) {
+    item.whitelisted = select.selectedIndex === 1;
+    Common.moduleSetting('whitelistedModules').set(Array.from(this._items)
+        .filter(item => item.whitelisted)
+        .map(item => item.name)
+        .join(','));
+  }
+};
+
+Ndb.NodeModulesBlackboxing._selectSymbol = Symbol('select');

--- a/front_end/ndb_ui/module.json
+++ b/front_end/ndb_ui/module.json
@@ -24,12 +24,21 @@
           "title": "Node processes",
           "persistence": "permanent",
           "className": "Ndb.NodeProcesses"
+      },
+      {
+          "type": "view",
+          "location": "settings-view",
+          "id": "node_modules_blackbox",
+          "title": "Node modules",
+          "order": 7,
+          "className": "Ndb.NodeModulesBlackboxing"
       }
   ],
   "dependencies": ["ui", "sources"],
   "scripts": [
       "RunConfiguration.js",
       "NodeProcesses.js",
+      "NodeModulesBlackboxing.js",
       "../node_modules/xterm/dist/xterm.js",
       "../node_modules/xterm/dist/addons/fit/fit.js",
       "Terminal.js"
@@ -37,6 +46,7 @@
   "resources": [
       "runConfiguration.css",
       "nodeProcesses.css",
+      "nodeModulesBlackboxing.css",
       "../node_modules/xterm/dist/xterm.css"
   ]
 }

--- a/front_end/ndb_ui/nodeModulesBlackboxing.css
+++ b/front_end/ndb_ui/nodeModulesBlackboxing.css
@@ -1,0 +1,67 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+.header {
+    padding: 0 0 6px;
+    border-bottom: 1px solid #EEEEEE;
+    font-size: 18px;
+    font-weight: normal;
+    flex: none;
+}
+
+.blackbox-everything-outside {
+    margin-top: 10px;
+    flex: none;
+}
+
+.dependency-list-empty {
+    flex: auto;
+    height: 30px;
+    max-height: 50px;
+    max-width: 300px;
+    display: flex;
+}
+
+.dependency-list {
+    margin-top: 10px;
+    max-width: 300px;
+    flex: 0 1 auto;
+    min-height: 30px;
+}
+
+.dependency-list-item {
+    padding: 3px 5px 3px 5px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    position: relative;
+    flex: auto 1 1;
+}
+
+.reload-button {
+	max-width: 200px;
+}
+
+.dependency-title {
+    flex: auto;
+    min-width: 100px;
+}
+
+.dependency-separator {
+    flex: 0 0 1px;
+    background-color: rgb(231, 231, 231);
+    height: 30px;
+    margin: 0 4px;
+}
+
+.dependency-behavior {
+	flex: 0 0 79px;
+    padding-left: 10px;
+}
+
+.dependency-behavior > select {
+    margin-left: -10px;
+}


### PR DESCRIPTION
- new tab is added to settings, called 'Node modules',
- user can whitelist some modules there.

User can see whitelisted modules in navigator and debug them in
debugger.

Fixes #45