### PR TITLE
Forward return value from callAndPauseOnStart() wrapper.

### DIFF
--- a/node_debug_demon/preload.js
+++ b/node_debug_demon/preload.js
@@ -40,7 +40,7 @@ try {
         const commandLineAPIDebug = debug;
         process.binding('inspector').callAndPauseOnStart = (fn, receiver, ...args) => {
           commandLineAPIDebug(fn);
-          fn.apply(receiver, args);
+          return fn.apply(receiver, args);
         };
       }
       wait = false;


### PR DESCRIPTION
CJS modules can return a result. Currently the `callAndPauseOnStart()` wrapper is not forwarding it along.