### PR TITLE
fix(frontend): clear sourcesContent inside sourceMap if redundant

### DIFF
--- a/front_end/ndb/NdbMain.js
+++ b/front_end/ndb/NdbMain.js
@@ -694,3 +694,24 @@ Bindings.CompilerScriptMapping.prototype._sourceMapDetached = function(event) {
   }
   this._debuggerWorkspaceBinding.updateLocations(script);
 };
+
+/**
+ * @param {string} sourceMapURL
+ * @param {string} compiledURL
+ * @return {!Promise<?SDK.TextSourceMap>}
+ * @this {SDK.TextSourceMap}
+ */
+SDK.TextSourceMap.load = async function(sourceMapURL, compiledURL) {
+  let callback;
+  const promise = new Promise(fulfill => callback = fulfill);
+  const {payload, error} = await loadSourceMap(sourceMapURL, compiledURL);
+  if (error || !payload)
+    return null;
+  try {
+    return new SDK.TextSourceMap(compiledURL, sourceMapURL, payload);
+  } catch (e) {
+    console.error(e);
+    Common.console.warn('DevTools failed to parse SourceMap: ' + sourceMapURL);
+    return null;
+  }
+}

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -8,7 +8,8 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const puppeteer = require('puppeteer');
-const {Writable} = require('stream');
+const readline = require('readline');
+const {Writable,Readable} = require('stream');
 const removeFolder = require('rimraf');
 const {URL} = require('url');
 const util = require('util');
@@ -44,7 +45,7 @@ async function launch(options) {
   });
   restoreProcessStreams();
 
-  const [frontend] = await browser.pages();
+  const frontend = (await browser.pages()).find(page => page.url().startsWith('data:text/html,'));
   frontend._client.send('Emulation.setDefaultBackgroundColorOverride',
       {color: {r: 0x24, g: 0x24, b: 0x24, a: 0xff}});
   frontend.on('close', browser.close.bind(browser));
@@ -81,7 +82,8 @@ async function launch(options) {
     }`),
     frontend.setRequestInterception(true),
     frontend.exposeFunction('openInNewTab', url => require('opn')(url)),
-    frontend.exposeFunction('copyText', text => require('clipboardy').write(text))
+    frontend.exposeFunction('copyText', text => require('clipboardy').write(text)),
+    frontend.exposeFunction('loadSourceMap', loadSourceMap)
   ]);
   fileSystemBackend.setSearchBackend(searchBackend);
   browser.on('disconnected', cleanupAndExit);
@@ -172,6 +174,84 @@ function prepareProcessStreams() {
 function restoreProcessStreams() {
   process.stderr.removeAllListeners('pipe');
   process.stdout.removeAllListeners('pipe');
+}
+
+async function loadSourceMap(sourceMapURL, compiledURL) {
+  try {
+    let payload;
+    const match = sourceMapURL.match(/^data:.+\/.+;base64,(.*)$/);
+    if (match) {
+      payload = JSON.parse(Buffer.from(match[1], 'base64').toString('utf8'));
+    } else {
+      const fileURL = new URL(sourceMapURL);
+      const content = await fsReadFile(fileURL, 'utf8');
+      payload = JSON.parse(content);
+    }
+    await removeSourceContentIfMatch(sourceMapURL, compiledURL, payload);
+    return {payload};
+  } catch (e) {
+    return {error: e.stack};
+  }
+}
+
+class StringStream extends Readable {
+  constructor(str) {
+    super();
+    this._str = str;
+    this._ended = false;
+  }
+
+  _read() {
+    if (this._ended)
+      return;
+    this._ended = true;
+    process.nextTick(_ => {
+      this.push(Buffer.from(this._str, 'utf8'));
+      this.push(null);
+    })
+  }
+};
+
+async function removeSourceContentIfMatch(sourceMapURL, compiledURL, payload) {
+  const {sourcesContent, sources} = payload;
+  if (!sourcesContent || !sources)
+    return;
+  for (let i = 0; i < sources.length; ++i) {
+    if (!sources[i] || !sourcesContent[i]) continue;
+    let url = sources[i];
+    if (!path.isAbsolute(url))
+      url = path.join(path.dirname(compiledURL), url);
+    if (!fs.existsSync(url))
+      continue;
+    const sourceContentStream = new StringStream(sourcesContent[i]);
+    const sourceContentLines = await readLines(sourceContentStream);
+    const fileStream = fs.createReadStream(url);
+    const fileStreamLines = await readLines(fileStream);
+    if (sourceContentLines.length === fileStreamLines.length) {
+      let equal = true;
+      for (let i = 0; i < sourceContentLines.length; ++i) {
+        if (sourceContentLines[i] != fileStreamLines[i]) {
+          equal = false;
+          break;
+        }
+      }
+      if (equal)
+        sourcesContent[i] = undefined;
+    }
+  }
+}
+
+async function readLines(stream) {
+  const rl = readline.createInterface({
+    input: stream,
+    crlfDelay: Infinity
+  });
+  return new Promise(resolve => {
+    stream.once('error', _ => resolve(null));
+    const lines = [];
+    rl.on('line', line => lines.push(line));
+    rl.on('close', _ => resolve(lines));
+  });
 }
 
 module.exports = {launch};


### PR DESCRIPTION
If we have target file with the same content inside file system we can just clear sourceContent inside sourceMap.

Fixes #34