### PR TITLE
feat(frontend): roll DevTools frontend to 582044

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -453,9 +453,10 @@
       }
     },
     "chrome-devtools-frontend": {
-      "version": "1.0.581469",
-      "resolved": "https://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.581469.tgz",
-      "integrity": "sha512-gt8hYPr+YJVc8ySd88fmdb9j+2y+nuF1lXxSCW7+MJcwxm7exRCpeWYeWH9CAN/fkPgZ17+xKl6XJ6QFJB7YlQ=="
+      "version": "1.0.582044",
+      "resolved": "https://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.582044.tgz",
+      "integrity": "sha512-xXpXbD+j5d1OwbAe2ypX7+D9miYGjOzDbKTK6S/krulrHtSTeMkwmYLIyw6OLFTdx6EarI7pkO/VxoU5mJfs5w==",
+      "dev": true
     },
     "ci-info": {
       "version": "1.1.3",
@@ -1312,11 +1313,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1329,15 +1332,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1440,7 +1446,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1450,6 +1457,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1462,17 +1470,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1489,6 +1500,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1561,7 +1573,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1571,6 +1584,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1676,6 +1690,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ndb-node-pty-prebuilt": "^0.8.0"
   },
   "devDependencies": {
-    "chrome-devtools-frontend": "1.0.581469",
+    "chrome-devtools-frontend": "1.0.582044",
     "eslint": "^4.19.1",
     "mocha": "^5.2.0",
     "uglify-es": "^3.3.9"


### PR DESCRIPTION
new frontend includes:
- better BigInt support for format string, e.g., console.log("%d", 1n),
- more reliable and fast CallStackSidebarPane.