### PR TITLE
feat(ndb-inspect): added --inspect like flag for ndb

### DIFF
--- a/front_end/ndb/NdbMain.js
+++ b/front_end/ndb/NdbMain.js
@@ -255,7 +255,9 @@ Ndb.NodeProcessManager = class extends Common.Object {
   static async _create() {
     const service = await Ndb.serviceManager.create('ndd_service');
     const instance = new Ndb.NodeProcessManager(SDK.targetManager, service);
-    instance._nddStore = await service.call('init');
+    instance._nddStore = await service.call('init', {
+      nddSharedStore: NdbProcessInfo.nddSharedStore
+    });
     Ndb.NodeProcessManager._instanceReady(instance);
     delete Ndb.NodeProcessManager._instanceReady;
   }

--- a/lib/file_system_backend.js
+++ b/lib/file_system_backend.js
@@ -209,7 +209,7 @@ class FileSystem {
       const data = stream.read();
       if (data)
         notify(readerId, 'data', data);
-    })
+    });
   }
 
   async _fileSystemWriteFile(name, fullPath, content) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -66,7 +66,7 @@ async function launch(options) {
   } catch (e) {
   }
   const preloadJs = path.join(userDataDir, 'preload.js');
-  await fsCopyFile(require.resolve('../services/preload.js'), preloadJs);
+  await fsCopyFile(require.resolve('../ndb-inspect/preload.js'), preloadJs);
   const [searchBackend, fileSystemBackend, services] = await Promise.all([
     SearchBackend.create(frontend),
     FileSystem.create(frontend),
@@ -80,7 +80,8 @@ async function launch(options) {
       serviceDir: path.join(__dirname, '..', 'services'),
       repl: require.resolve('./repl.js'),
       pkg: pkg,
-      preload: preloadJs
+      preload: preloadJs,
+      nddSharedStore: path.join(options.configDir, 'ndd_store')
     })};`),
     frontend.evaluateOnNewDocument(`function callFrontend(f) {
       ${options.debugFrontend ? 'setTimeout(_ => f(), 0)' : 'f()'}
@@ -116,6 +117,9 @@ async function launch(options) {
 async function setupUserDataDir(configDirectory, doNotCopyPreferences) {
   if (!fs.existsSync(configDirectory))
     await fsMkdir(configDirectory);
+
+  if (!fs.existsSync(path.join(configDirectory, 'ndd_store')))
+    await fsMkdir(path.join(configDirectory, 'ndd_store'));
 
   const chromiumPreferencesFile = path.join(configDirectory, 'ChromiumPreferences');
   if (!fs.existsSync(chromiumPreferencesFile))

--- a/ndb-inspect/.gitignore
+++ b/ndb-inspect/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+*.swp
+*.pyc
+.vscode

--- a/ndb-inspect/LICENSE
+++ b/ndb-inspect/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Google Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ndb-inspect/README.md
+++ b/ndb-inspect/README.md
@@ -1,0 +1,21 @@
+# ndb-inspect
+
+> --inspect -> -r ndb-inspect, --inspect-brk -> -r ndb-inspect/brk
+
+## Getting Started
+
+Add ndb-inspect to list of dev depencies of your project. ndb-inspect is tiny package without dependencies.
+```bash
+npm install --save-dev ndb-inspect
+```
+
+## What can I do?
+
+You can:
+1. replace any usage of `--inspect` with `-r ndb-inspect`,
+2. replace any usage of `--inspect-brk` with `-r ndb-inspect/brk`,
+3. run any node script from your terminal with `-r ndb-inspect` flag to debug it using `ndb`.
+
+## Contributing
+
+Check out [contributing guide](https://github.com/GoogleChromeLabs/ndb/blob/master/CONTRIBUTING.md) to get an overview of ndb development.

--- a/ndb-inspect/brk
+++ b/ndb-inspect/brk
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const ndbDir = path.join(os.homedir(), '.ndb');
+if (!fs.existsSync(ndbDir))
+  fs.mkdirSync(ndbDir);
+const nddStoreDir = path.join(ndbDir, 'ndd_store');
+if (!fs.existsSync(nddStoreDir))
+  fs.mkdirSync(nddStoreDir);
+
+process.env.NDD_STORE = path.join(os.homedir(), '.ndb', 'ndd_store');
+process.env.NDD_WAIT_FOR_CONNECTION = 1;
+process.env.NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + ' -r ndb-inspect/brk';
+
+require('./preload.js');

--- a/ndb-inspect/inspect.js
+++ b/ndb-inspect/inspect.js
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const ndbDir = path.join(os.homedir(), '.ndb');
+if (!fs.existsSync(ndbDir))
+  fs.mkdirSync(ndbDir);
+const nddStoreDir = path.join(ndbDir, 'ndd_store');
+if (!fs.existsSync(nddStoreDir))
+  fs.mkdirSync(nddStoreDir);
+
+process.env.NDD_STORE = nddStoreDir;
+process.env.NDD_WAIT_FOR_CONNECTION = 0;
+process.env.NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + ' -r ndb-inspect';
+
+require('./preload.js');

--- a/ndb-inspect/package.json
+++ b/ndb-inspect/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ndb-inspect",
+  "version": "0.0.1",
+  "description": "--inspect flag alternative to debug with ndb",
+  "main": "inspect.js",
+  "repository": "github:GoogleChromeLabs/ndb",
+  "homepage": "https://github.com/GoogleChromeLabs/ndb#readme",
+  "engines": {
+    "node": ">=8.9.0"
+  },
+  "author": "The Chromium Authors",
+  "license": "Apache-2.0"
+}

--- a/ndb-inspect/preload.js
+++ b/ndb-inspect/preload.js
@@ -14,6 +14,7 @@ try {
   const nddStore = process.env.NDD_STORE;
   const nddParentProcessId = process.env.NDD_PPID;
   const nddData = process.env.NDD_DATA;
+  const nddWaitForConnection = process.env.NDD_WAIT_FOR_CONNECTION;
 
   process.env.NDD_PPID = process.pid;
   process.once('exit', _ => fs.unlinkSync(stateFileName));
@@ -46,7 +47,7 @@ try {
   }));
 
   inspector.close();
-  inspector.open(port, undefined, true);
+  inspector.open(port, undefined, nddWaitForConnection !== '0');
   delete process.breakAtStart;
 } catch (e) {
 }

--- a/scripts/build_release_application.js
+++ b/scripts/build_release_application.js
@@ -9,7 +9,7 @@ const path = require('path');
 const readline = require('readline');
 const util = require('util');
 
-const Terser = require("terser");
+const Terser = require('terser');
 
 const fsReadFile = util.promisify(fs.readFile);
 
@@ -136,7 +136,7 @@ class ReleaseBuilder {
     await this._copyFile(this._lookupFile('favicon.ico'), path.join(this._output, 'favicon.ico'));
     await util.promisify(fs.mkdir)(path.join(this._output, 'Images'));
     await Promise.all(Array.from(this._images)
-      .map(image => this._copyFile(this._lookupFile(path.join('Images', image)), path.join(this._output, 'Images', image))));
+        .map(image => this._copyFile(this._lookupFile(path.join('Images', image)), path.join(this._output, 'Images', image))));
   }
 
   _topologicalSort(modules) {

--- a/services/terminal.js
+++ b/services/terminal.js
@@ -34,6 +34,7 @@ class Terminal extends ServiceBase {
         ...process.env,
         NODE_OPTIONS: `--require ${params.preload}`,
         NDD_STORE: params.nddStore,
+        NDD_WAIT_FOR_CONNECTION: 1,
         NDB_VERSION
       }
     });


### PR DESCRIPTION
ndb-inspect is trivial package, that allow to replace --inspect
and --inspect-brk with -r ndb-inspect and -r ndb-inspect/brk.