### PR TITLE
feat(perf): add timeline panel

### DIFF
--- a/front_end/ndb/module.json
+++ b/front_end/ndb/module.json
@@ -21,14 +21,6 @@
         {
             "type": "setting",
             "category": "Debugger",
-            "title": "Wait at end",
-            "settingName": "waitAtEnd",
-            "settingType": "boolean",
-            "defaultValue": false
-        },
-        {
-            "type": "setting",
-            "category": "Debugger",
             "title": "Autostart main",
             "settingName": "autoStartMain",
             "settingType": "boolean",

--- a/front_end/ndb_app.json
+++ b/front_end/ndb_app.json
@@ -1,7 +1,11 @@
 {
   "modules" : [
      { "name": "ndb", "type": "autostart" },
-     { "name": "js_profiler" },
+     { "name": "layer_viewer" },
+     { "name": "timeline_model" },
+     { "name": "timeline" },
+     { "name": "product_registry" },
+     { "name": "mobile_throttling" },
      { "name": "ndb_ui" }
  ],
   "extends": "shell",

--- a/front_end/ndb_ui/NodeProcesses.js
+++ b/front_end/ndb_ui/NodeProcesses.js
@@ -38,10 +38,6 @@ Ndb.NodeProcesses = class extends UI.VBox {
         Common.UIString('Pause at start'));
     this._pauseAtStartCheckbox.element.id = 'pause-at-start-checkbox';
     toolbar.appendToolbarItem(this._pauseAtStartCheckbox);
-    this._waitAtEndCheckbox = new UI.ToolbarSettingCheckbox(
-        Common.moduleSetting('waitAtEnd'), Common.UIString('Stay attached when process is finished.'),
-        Common.UIString('Stay attached'));
-    toolbar.appendToolbarItem(this._waitAtEndCheckbox);
 
     this._emptyElement = this.contentElement.createChild('div', 'gray-info-message');
     this._emptyElement.id = 'no-running-nodes-msg';

--- a/front_end/ndb_ui/RunConfiguration.js
+++ b/front_end/ndb_ui/RunConfiguration.js
@@ -52,12 +52,23 @@ Ndb.RunConfiguration = class extends UI.VBox {
     const runButton = new UI.ToolbarButton(Common.UIString('Run'), 'largeicon-play');
     runButton.addEventListener(UI.ToolbarButton.Events.Click, this._runConfig.bind(this, item.execPath, item.args));
     toolbar.appendToolbarItem(runButton);
+    const profileButton = new UI.ToolbarButton(Common.UIString('Start recording..'), 'largeicon-start-recording');
+    profileButton.addEventListener(UI.ToolbarButton.Events.Click, this._profileConfig.bind(this, item.execPath, item.args));
+    toolbar.appendToolbarItem(profileButton);
     return f.element();
   }
 
   async _runConfig(execPath, args) {
     const manager = await Ndb.NodeProcessManager.instance();
     await manager.debug(execPath, args);
+  }
+
+  async _profileConfig(execPath, args) {
+    await UI.viewManager.showView('timeline');
+    await Common.console.showPromise();
+    const action = UI.actionRegistry.action('timeline.toggle-recording');
+    await action.execute();
+    await this._runConfig(execPath, args);
   }
 
   /**

--- a/front_end/ndb_ui/module.json
+++ b/front_end/ndb_ui/module.json
@@ -34,7 +34,7 @@
           "className": "Ndb.NodeModulesBlackboxing"
       }
   ],
-  "dependencies": ["ui", "sources"],
+  "dependencies": ["ui", "sources", "timeline"],
   "scripts": [
       "RunConfiguration.js",
       "NodeProcesses.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -453,9 +453,9 @@
       }
     },
     "chrome-devtools-frontend": {
-      "version": "1.0.589976",
-      "resolved": "https://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.589976.tgz",
-      "integrity": "sha512-z4xCSWW8MjqSCdd29HYxlmlQtp7vKqI9LdYjMHPRYGQIEDgkizT93FzC1SxfDEWEdFO25JxF/XNaPC5yRg54VQ==",
+      "version": "1.0.591147",
+      "resolved": "https://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.591147.tgz",
+      "integrity": "sha512-gJybkPhHzZfF0ftnaWNERkJdyYUhvZidpE4EEZS1HL42gSK6OiZW8G1Sgie1DNHGg3c5CuFkBRbnO+DXSKJW5Q==",
       "dev": true
     },
     "ci-info": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ndb-node-pty-prebuilt": "^0.8.0"
   },
   "devDependencies": {
-    "chrome-devtools-frontend": "1.0.589976",
+    "chrome-devtools-frontend": "1.0.591147",
     "eslint": "^4.19.1",
     "mocha": "^5.2.0",
     "terser": "^3.8.2"


### PR DESCRIPTION
There are three possible ways to use performance panel:
- run target script with "Pause at start", go to performance panel
  and start recording,
- start recording on performance panel, open terminal in drawer
  and run any node script from there.
- using "Start recording.." button in NPM scripts sidebar.

As bonus:
- removed "Wait at end" checkbox.