### PR TITLE
fix(repl): use console.log for old Node 8.x releases

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-console.context('repl').log('Welcome to the ndb %cR%cE%cP%cL%c!',
-    'color:#8bc34a', 'color:#ffc107', 'color:#ff5722', 'color:#2196f3', 'color:inherit');
+const logger = console.context ? console.context('repl') : console;
+logger.log('Welcome to the ndb %cR%cE%cP%cL%c!',
+  'color:#8bc34a', 'color:#ffc107', 'color:#ff5722', 'color:#2196f3', 'color:inherit');
 setInterval(_ => 0, 2147483647);


### PR DESCRIPTION
console.context does not exist until specific 8.x release.
Use console.log as workaround.

Fixes #136