### PR TITLE
fix(ndb/inspect): ndb should pause at start with ndb/inspect-brk

### DIFF
--- a/front_end/ndb/NdbMain.js
+++ b/front_end/ndb/NdbMain.js
@@ -180,6 +180,8 @@ Ndb.NodeProcessManager = class extends Common.Object {
     await target.runtimeAgent().runIfWaitingForDebugger();
 
     function shouldPauseAtStart(environment, argv) {
+      if (argv.find(arg => arg.endsWith('ndb/inspect-brk')))
+        return true;
       if (!Common.moduleSetting('pauseAtStart').get())
         return false;
       const [_, arg] = argv;

--- a/inspect
+++ b/inspect
@@ -17,6 +17,9 @@ if (!fs.existsSync(nddStoreDir))
 
 process.env.NDD_STORE = nddStoreDir;
 process.env.NDD_WAIT_FOR_CONNECTION = 0;
-process.env.NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + ' -r ndb/inspect';
+let options = process.env.NODE_OPTIONS || '';
+if (!options.includes('ndb/inspect'))
+  options += ' -r ndb/inspect';
+process.env.NODE_OPTIONS = options;
 
 require('./lib/preload.js');

--- a/inspect-brk
+++ b/inspect-brk
@@ -17,6 +17,9 @@ if (!fs.existsSync(nddStoreDir))
 
 process.env.NDD_STORE = nddStoreDir;
 process.env.NDD_WAIT_FOR_CONNECTION = 1;
-process.env.NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + ' -r ndb/inspect-brk';
+let options = process.env.NODE_OPTIONS || '';
+if (!options.includes('ndb/inspect-brk'))
+  options += ' -r ndb/inspect-brk';
+process.env.NODE_OPTIONS = options;
 
 require('./lib/preload.js');


### PR DESCRIPTION
To align -r ndb/inspect-brk behavior with --inspect-brk, we should
force pause at start if arguments contain ndb/inspect-brk.