### PR TITLE
fix(ndd,fs): use fs.watch instead of chokidar in ndd

### DIFF
--- a/lib/process_utility.js
+++ b/lib/process_utility.js
@@ -11,6 +11,7 @@ function prepareProcess(disposeCallback) {
     // mute carlo rpc errors
     if (error.message === 'Channel closed')
       return;
+    console.log(error);
     process.exit(1);
   });
   // dispose when child process is disconnected

--- a/package-lock.json
+++ b/package-lock.json
@@ -1231,11 +1231,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1248,15 +1250,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1359,7 +1364,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1369,6 +1375,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1381,17 +1388,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1408,6 +1418,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1480,7 +1491,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1490,6 +1502,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1595,6 +1608,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/services/file_system.js
+++ b/services/file_system.js
@@ -145,6 +145,7 @@ class FileSystemHandler {
       depth: 0,
       ignorePermissionErrors: true
     });
+    watcher.on('error', error => 0);
     const SUBSCRIPTION = new Set(['add', 'change', 'unlink']);
     const events = [];
     let timer = null;


### PR DESCRIPTION
- fs.watch is more reliable in case when there is no free space for
new inotify handles, ndd can use it instead of chokidar,
- fs service should be ready for ENOSPC errors.