### PR TITLE
fix: preload.js file not found

### DIFF
--- a/services/ndd_service.js
+++ b/services/ndd_service.js
@@ -149,7 +149,7 @@ class NddService {
       nodePath += process.platform === 'win32' ? ';' : ':';
     nodePath += path.join(__dirname, '..', 'lib', 'preload');
     const env = {
-      NODE_OPTIONS: `--require ndb/preload.js`,
+      NODE_OPTIONS: `--require ${path.join(nodePath, 'ndb/preload.js')}`,
       NODE_PATH: nodePath,
       NDD_STORE: this._nddStores[0],
       NDD_WAIT_FOR_CONNECTION: 1,

--- a/services/terminal.js
+++ b/services/terminal.js
@@ -26,7 +26,7 @@ class Terminal {
       cwd: process.cwd(),
       env: {
         ...process.env,
-        NODE_OPTIONS: `--require ndb/preload.js`,
+        NODE_OPTIONS: `--require ${path.join(nodePath, 'ndb/preload.js')}`,
         NDD_STORE: nddStore,
         NDD_WAIT_FOR_CONNECTION: 1,
         NODE_PATH: nodePath,


### PR DESCRIPTION
## Env
Node: v10.13.0
ndb: v1.0.42

fix the following error when start to run

![image](https://user-images.githubusercontent.com/3326901/51234579-1213d300-19a8-11e9-8f71-c050fa9dbed9.png)