### PR TITLE
fix(preload): Avoid mysterious binding.unlink error message.

### DIFF
--- a/lib/preload/ndb/preload.js
+++ b/lib/preload/ndb/preload.js
@@ -17,7 +17,6 @@ try {
   const nddWaitForConnection = process.env.NDD_WAIT_FOR_CONNECTION;
 
   process.env.NDD_PPID = process.pid;
-  process.once('exit', _ => fs.unlinkSync(stateFileName));
   process.breakAtStart = _ => {
     process._breakFirstLine = true;
     const commandLineAPIDebug = debug;
@@ -39,17 +38,22 @@ try {
 
   const sep = process.platform === 'win32' ? '\\' : '/';
   const stateFileName = `${nddStore}${sep}${process.pid}`;
-  fs.writeFileSync(stateFileName, JSON.stringify({
+  fs.writeFile(stateFileName, JSON.stringify({
     targetListUrl: targetListUrl,
     ppid: nddParentProcessId,
     data: nddData,
     argv: process.argv.concat(process.execArgv),
     cwd: process.cwd()
-  }));
-
-  inspector.close();
-  inspector.open(port, undefined, nddWaitForConnection !== '0');
-  delete process.breakAtStart;
+  }), err => {
+    if (err) {
+      console.error(`Failed to save state in ${stateFileName}: ${err}`);
+    } else {
+      process.once('exit', _ => fs.unlinkSync(stateFileName));
+      inspector.close();
+      inspector.open(port, undefined, nddWaitForConnection !== '0');
+      delete process.breakAtStart;
+    }
+  });
 } catch (e) {
 }
 // eslint-disable-next-line spaced-comment


### PR DESCRIPTION
If the state file cannot be written, the error causes the process to exit
and the exit event processor reports eg
fs.js:1061
  return binding.unlink(pathModule._makeLong(path));
                 ^

Error: ENOENT: no such file or directory, unlink 'undefined/258755'
followed by a stacktrace.

To avoid this, don't add the handler until we succeed at saving the state file.
Also print the error from saving so the user can know something went wrong.