### PR TITLE
Log the stack for unhandledRejections

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -13,7 +13,7 @@ const { Backend } = require('./backend.js');
 process.on('unhandledRejection', error => {
   if (error.message.includes('Protocol error') && error.message.includes('Target closed'))
     process.exit(1);
-  console.log('unhandledRejection', error.message);
+  console.log('unhandledRejection', error.stack || error.message);
 });
 
 async function launch() {


### PR DESCRIPTION
For internal errors the message alone is not very helpful. For example I got net::ERR_NAME_NOT_RESOLVED at <url>,
but I have no idea where this came from or why. With the call stack I can see the issue is in FrameManager.navigate().