### PR TITLE
fix(carlo): use chromium always

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -21,7 +21,7 @@ async function launch() {
   try {
     app = await carlo.launch({
       bgcolor: '#242424',
-      channel: ['stable', 'canary', 'chromium'],
+      channel: ['chromium'],
       paramsForReuse: {
         cwd: process.cwd(),
         argv: process.argv
@@ -37,6 +37,7 @@ async function launch() {
   const appName = 'ndb';
   const debugFrontend = !!process.env.NDB_DEBUG_FRONTEND;
 
+  app.setIcon(path.join(__dirname, '..', 'front_end', 'favicon.png'));
   const overridesFolder = debugFrontend
     ? path.dirname(require.resolve(`../front_end/${appName}.json`))
     : path.join(__dirname, '..', '.local-frontend');


### PR DESCRIPTION
As long as carlo has issue 141 [1] we can not use it with stable or
canary.
drive-by: added nice icon.

[1] https://github.com/GoogleChromeLabs/carlo/issues/141