### PR TITLE
feat(profiler): auto stop profiler when app is finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,14 @@ ndb .
 # In Sources panel > "NPM Scripts" sidebar, click the selected "Run" button 
 ```
 
+- Use `Ctrl`/`Cmd` + `R` to restart last run
 - Run any node command from within ndb's integrated terminal and ndb will connect automatically
 - Run any open script source by using 'Run this script' context menu item, ndb will connect automatically as well
+
+- Use `--prof` flag to profile your app, `Ctrl`/`Cmd` + `R` restarts profiling
+```bash
+ndb --prof npm run unit
+```
 
 ## What can I do?
 

--- a/front_end/ndb_ui/RunConfiguration.js
+++ b/front_end/ndb_ui/RunConfiguration.js
@@ -70,11 +70,7 @@ Ndb.RunConfiguration = class extends UI.VBox {
   }
 
   async _profileConfig(execPath, args) {
-    await UI.viewManager.showView('timeline');
-    await Common.console.showPromise();
-    const action = UI.actionRegistry.action('timeline.toggle-recording');
-    await action.execute();
-    await this._runConfig(execPath || await this._npmExecPath(), args);
+    await Ndb.nodeProcessManager.profile(execPath || await this._npmExecPath(), args);
   }
 
   /**


### PR DESCRIPTION
User can click record button next to configuration on bottom left
side of the sources panel. This button start profiler for given
process and run it as long as process is allive.

User can add --prof flag to ndb to profile entire app run,
e.g. ndb --prof npm run unit

Ctrl/Cmd + R restarts last profiling.