### PR TITLE
fix(frontend): InspectorFrontendHost.loadNetworkResource override

### DIFF
--- a/front_end/ndb/InspectorFrontendHostOverrides.js
+++ b/front_end/ndb/InspectorFrontendHostOverrides.js
@@ -17,8 +17,17 @@
     callback(prefs);
   };
 
-  InspectorFrontendHost.isHostedMode = _ => false;
+  InspectorFrontendHost.isHostedMode = () => false;
   InspectorFrontendHost.copyText = text => navigator.clipboard.writeText(text);
   InspectorFrontendHost.openInNewTab = url => Ndb.backend.openInNewTab(url);
   InspectorFrontendHost.bringToFront = () => Ndb.backend.bringToFront();
+  InspectorFrontendHost.loadNetworkResource = async(url, headers, streamId, callback) => {
+    const text = await Ndb.backend.loadNetworkResource(url, headers);
+    if (text) {
+      Host.ResourceLoader.streamWrite(streamId, text);
+      callback({statusCode: 200});
+    } else {
+      callback({statusCode: 404});
+    }
+  };
 })();

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -91,6 +91,19 @@ class Backend {
   processInfo() {
     return this._info;
   }
+
+  async loadNetworkResource(url, headers) {
+    try {
+      if (url.startsWith('file://')) {
+        const fileURL = new URL(url);
+        return await fsReadFile(fileURL, 'utf8');
+      } else {
+        return null;
+      }
+    } catch (e) {
+      return null;
+    }
+  }
 }
 
 async function loadSourceMap(sourceMapURL, compiledURL) {


### PR DESCRIPTION
All urls in ndb are file urls, host method should be able to load file.

Fixes https://github.com/GoogleChromeLabs/ndb/issues/232