### PR TITLE
feat(preload): remove port guessing from preload.js

### DIFF
--- a/lib/preload/ndb/preload.js
+++ b/lib/preload/ndb/preload.js
@@ -6,22 +6,13 @@
 
 try {
   const inspector = require('inspector');
-  const fs = require('fs');
-  const url = require('url');
-
+  const { writeFileSync, unlinkSync } = require('fs');
   inspector.open(0, undefined, false);
-  const inspectorUrl = url.parse(inspector.url());
-  inspectorUrl.pathname = '/json';
-  inspectorUrl.protocol = 'http';
-  const targetListUrl = url.format(inspectorUrl);
-
   const sep = process.platform === 'win32' ? '\\' : '/';
   const fileName = `${process.env.NDD_STORE}${sep}${process.pid}`;
-  process.once('exit', _ => fs.unlinkSync(fileName));
-  fs.writeFileSync(fileName, targetListUrl);
-
-  inspector.close();
-  inspector.open(Number(inspectorUrl.port), undefined, true);
+  writeFileSync(fileName, inspector.url());
+  process.once('exit', _ => unlinkSync(fileName));
+  inspector.open(0, undefined, true);
 } catch (e) {
 }
 // eslint-disable-next-line spaced-comment

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "github:GoogleChromeLabs/ndb",
   "homepage": "https://github.com/GoogleChromeLabs/ndb#readme",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "bin": {
     "ndb": "./ndb.js"


### PR DESCRIPTION
With new approach we can get web socket inspector url without
additional inspector.close() call and without fetching it from
/json endpoint.

Unfortunately Node 8 does not work well with this change but at
the same time Node 8 is not active based on [1] so we can drop its
support to get more freedom in implementing new features.

[1] https://github.com/nodejs/Release