### PR TITLE
chore(npmignore): added *.tgz to avoid publishing packed package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,3 +17,4 @@ yarn.lock
 .eslintignore
 .eslintrc.js
 README.md
+ndb-*.tgz


### PR DESCRIPTION
1.0.51 was published with 1.0.50.tgz pkg inside. :(