### PR TITLE
fix(node8): fixed node 8 support

### DIFF
--- a/front_end/ndb_ui/NodeProcesses.js
+++ b/front_end/ndb_ui/NodeProcesses.js
@@ -31,9 +31,6 @@ Ndb.NodeProcesses = class extends UI.VBox {
     this._treeOutline.element.classList.add('hidden');
 
     this._targetToUI = new Map();
-
-    SDK.targetManager.addModelListener(
-        SDK.RuntimeModel, SDK.RuntimeModel.Events.ExecutionContextChanged, this._onExecutionContextChanged, this);
     SDK.targetManager.observeTargets(this);
   }
 
@@ -47,11 +44,9 @@ Ndb.NodeProcesses = class extends UI.VBox {
     const processInfo = await Ndb.nodeProcessManager.infoForTarget(target);
     if (!processInfo || processInfo.isRepl())
       return;
-    const runtimeModel = target.model(SDK.RuntimeModel);
-    const executionContext = runtimeModel && runtimeModel.defaultExecutionContext();
     const f = UI.Fragment.build`
       <div class=process-item>
-        <div $=title class=process-title>${executionContext ? executionContext.label() : 'node'}</div>
+        <div class=process-title>${processInfo.userFriendlyName()}</div>
         <div $=state class=process-item-state></div>
       </div>
       <div class='controls-container fill'>
@@ -122,13 +117,5 @@ Ndb.NodeProcesses = class extends UI.VBox {
     const treeElement = this._targetToUI.get(target);
     if (treeElement)
       treeElement.select();
-  }
-
-  _onExecutionContextChanged({data: executionContext}) {
-    if (executionContext.isDefault) {
-      const ui = this._targetToUI.get(executionContext.target());
-      if (ui)
-        ui.f.$('title').textContent = executionContext.label();
-    }
   }
 };

--- a/lib/preload/ndb/preload.js
+++ b/lib/preload/ndb/preload.js
@@ -7,21 +7,47 @@
 try {
   const inspector = require('inspector');
   const fs = require('fs');
-  const url = require('url');
-
-  inspector.open(0, undefined, false);
-  const inspectorUrl = url.parse(inspector.url());
-  inspectorUrl.pathname = '/json';
-  inspectorUrl.protocol = 'http';
-  const targetListUrl = url.format(inspectorUrl);
-
+  let inspectorPort = 0;
+  inspector.open(inspectorPort, undefined, false);
+  let inspectorUrl = inspector.url();
+  if (process.version.startsWith('v8.')) {
+    const url = require('url');
+    const parsedInspectorUrl = url.parse(inspectorUrl);
+    parsedInspectorUrl.pathname = '/json';
+    parsedInspectorUrl.protocol = 'http';
+    inspectorUrl = url.format(parsedInspectorUrl);
+    inspectorPort = Number(parsedInspectorUrl.port);
+  }
   const sep = process.platform === 'win32' ? '\\' : '/';
   const fileName = `${process.env.NDD_STORE}${sep}${process.pid}`;
-  process.once('exit', _ => fs.unlinkSync(fileName));
-  fs.writeFileSync(fileName, targetListUrl);
+  process.once('exit', fs.unlinkSync.bind(null, fileName));
+  const info = fetchProcessInfo();
+  info.inspectorUrl = inspectorUrl;
+  fs.writeFileSync(fileName, JSON.stringify(info));
+  if (process.version.startsWith('v8.')) {
+    inspector.close();
+    inspector.open(inspectorPort, undefined, true);
+  } else {
+    inspector.open(inspectorPort, undefined, true);
+  }
 
-  inspector.close();
-  inspector.open(Number(inspectorUrl.port), undefined, true);
+  function fetchProcessInfo() {
+    let scriptName = '';
+    try {
+      scriptName = require.resolve(process.argv[1]);
+    } catch (e) {
+    }
+    const ppid = process.env.NDD_PPID;
+    process.env.NDD_PPID = process.pid;
+    process.versions['ndb'] = process.env.NDB_VERSION;
+    return {
+      cwd: process.cwd(),
+      argv: process.argv.concat(process.execArgv),
+      data: process.env.NDD_DATA,
+      ppid: ppid,
+      scriptName: scriptName
+    };
+  }
 } catch (e) {
 }
 // eslint-disable-next-line spaced-comment


### PR DESCRIPTION
Node 8 can not process any command before `Runtime.runIfWaitingForDebugger` so preload should fetch all required information by itself and send it to frontend using file.

It allows to simplify some parts of frontend  - we do not need to listen for target name changes any more - it never changes.

drive-by: we do not need to fetch web socket url from http endpoint for Node 10 and Node 12.