### PR TITLE
fix(sourcemap): only first line mappings should be adjusted

### DIFF
--- a/front_end/ndb/NdbMain.js
+++ b/front_end/ndb/NdbMain.js
@@ -368,23 +368,6 @@ DOMTokenList.prototype.toggle = function(token, force) {
 };
 
 /**
- * @param {string} sourceURL
- * @param {string} modulePrefix
- * @param {SDK.DebuggerModel} debuggerModel
- * @return {!Promise<boolean>}
- */
-async function isNodeWrappedModule(sourceURL, modulePrefix, debuggerModel) {
-  for (const script of debuggerModel.scripts()) {
-    if (script.sourceURL === sourceURL) {
-      const content = await script.originalContentProvider().requestContent();
-      return content.startsWith(modulePrefix);
-    }
-  }
-
-  return false;
-}
-
-/**
  * @param {string} sourceMapURL
  * @param {string} compiledURL
  * @return {!Promise<?SDK.TextSourceMap>}
@@ -399,21 +382,21 @@ SDK.TextSourceMap.load = async function(sourceMapURL, compiledURL) {
   try {
     textSourceMap = new SDK.TextSourceMap(compiledURL, sourceMapURL, payload);
   } catch (e) {
-    console.error(e);
     Common.console.warn('DevTools failed to parse SourceMap: ' + sourceMapURL);
     return null;
   }
 
-  if (textSourceMap._baseURL.startsWith('file://')) {
-    try {
-      const modulePrefix = await Ndb.backend.getNodeScriptPrefix();
-      const debuggerModel = Array.from(Bindings.debuggerWorkspaceBinding._debuggerModelToData.keys())[1];
-      if (await isNodeWrappedModule(compiledURL, modulePrefix, debuggerModel))
-        for (const mapping of textSourceMap.mappings()) mapping.columnNumber += modulePrefix.length;
-    } catch (e) {
-      console.error(e);
-      Common.console.warn('DevTools failed to fix SourceMap for node script: ' + sourceMapURL);
-      // return the source map anyways.
+  const modulePrefix = await Ndb.backend.getNodeScriptPrefix();
+  for (const uiSourceCode of Workspace.workspace.uiSourceCodes()) {
+    if (uiSourceCode.url() === compiledURL && uiSourceCode.project().type() === Workspace.projectTypes.Network) {
+      const content = await uiSourceCode.requestContent();
+      if (content.startsWith(modulePrefix)) {
+        for (const mapping of textSourceMap.mappings()) {
+          if (!mapping.lineNumber)
+            mapping.columnNumber += modulePrefix.length;
+        }
+        break;
+      }
     }
   }
 

--- a/front_end/ndb_ui/NodeProcesses.js
+++ b/front_end/ndb_ui/NodeProcesses.js
@@ -4,12 +4,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-UI.context.addFlavorChangeListener(SDK.DebuggerPausedDetails, _ => {
-  const details = UI.context.flavor(SDK.DebuggerPausedDetails);
-  if (!details)
-    UI.context.setFlavor(SDK.DebuggerModel.CallFrame, null);
-});
-
 Ndb.NodeProcesses = class extends UI.VBox {
   constructor() {
     super(true);
@@ -60,7 +54,7 @@ Ndb.NodeProcesses = class extends UI.VBox {
     debuggerModel.addEventListener(SDK.DebuggerModel.Events.DebuggerResumed, () => {
       f.$('state').textContent = 'attached';
     });
-    f.$('state').textContent = 'attached';
+    f.$('state').textContent = debuggerModel.isPaused() ? 'paused' : 'attached';
 
     const buttons = f.$('controls-buttons');
     const toolbar = new UI.Toolbar('', buttons);


### PR DESCRIPTION
node reports scripts with wrapper, source maps are generated without
wrapper, we need to adjust first line mappings in source map.

drive-by: fix 'paused' state of node process.