### PR TITLE
fix(ndd): ndd service should not use process.stdout

### DIFF
--- a/front_end/ndb/NdbMain.js
+++ b/front_end/ndb/NdbMain.js
@@ -236,6 +236,14 @@ Ndb.NodeProcessManager = class extends Common.Object {
     }
   }
 
+  async terminalData(stream, data) {
+    const content = await(await fetch(`data:application/octet-stream;base64,${data}`)).text();
+    if (content.startsWith('Debugger listening on') || content.startsWith('Debugger attached.') || content.startsWith('Waiting for the debugger to disconnect...'))
+      return;
+    await Ndb.backend.writeTerminalData(stream, data);
+    this.dispatchEventToListeners(Ndb.NodeProcessManager.Events.TerminalData, content);
+  }
+
   async _onExecutionContextDestroyed(event) {
     const executionContext = event.data;
     if (!executionContext.isDefault)
@@ -342,6 +350,10 @@ Ndb.NodeProcessManager = class extends Common.Object {
     else
       await this.profile(execPath, args);
   }
+};
+
+Ndb.NodeProcessManager.Events = {
+  TerminalData: Symbol('terminalData')
 };
 
 /**

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -92,6 +92,14 @@ class Backend {
     return this._info;
   }
 
+  writeTerminalData(stream, data) {
+    const buffer = Buffer.from(data, 'base64');
+    if (stream === 'stderr')
+      process.stderr.write(buffer);
+    else if (stream === 'stdout')
+      process.stdout.write(buffer);
+  }
+
   async loadNetworkResource(url, headers) {
     try {
       if (url.startsWith('file://')) {

--- a/services/terminal.js
+++ b/services/terminal.js
@@ -46,13 +46,14 @@ class Terminal {
   }
 }
 
-function init(frontend, env, cols, rows) {
+async function init(frontend, env, cols, rows) {
   try {
     const pty = require('node-pty');
     return rpc.handle(new Terminal(frontend, pty, env, cols, rows));
   } catch (e) {
-    frontend.initFailed(e.stack);
-    process.exit(0);
+    await frontend.initFailed(e.stack);
+    setImmediate(() => process.exit(0));
+    return null;
   }
 }
 


### PR DESCRIPTION
carlo spawns child processes with detach flag. We should route
terminal data through frontend to show it in main process stdout.

The big bug: https://github.com/GoogleChromeLabs/ndb/issues/204
drive-by: fixed https://github.com/GoogleChromeLabs/ndb/issues/168