### PR TITLE
refactor(backend): inline NDB_VERSION

### DIFF
--- a/lib/preload/ndb/preload.js
+++ b/lib/preload/ndb/preload.js
@@ -25,14 +25,16 @@
     process.env.NDD_PPID = process.pid;
     if (!process.env.NDD_DATA)
       process.env.NDD_DATA = process.pid + '_ndbId';
-    process.versions['ndb'] = process.env.NDB_VERSION;
+    process.versions['ndb'] = '1.1.0';
+    const inspector = require('inspector');
+    inspector.open(0, undefined, false);
     const info = {
       cwd: process.cwd(),
       argv: process.argv.concat(process.execArgv),
       data: process.env.NDD_DATA,
       ppid: ppid,
       id: String(process.pid),
-      inspectorUrl: require('inspector').url(),
+      inspectorUrl: inspector.url(),
       scriptName: scriptName
     };
     const {execFileSync} = require('child_process');

--- a/package.json
+++ b/package.json
@@ -14,12 +14,8 @@
   "scripts": {
     "lint": "./node_modules/.bin/eslint .",
     "prepare": "node build.js",
-    "dummyScriptForTest": "node -e 'console.log(239)'",
-    "unit": "./node_modules/mocha/bin/mocha test/test.js",
-    "integration": "node test/integration.js",
-    "test-platform": "node test/platform.spec.js",
     "test": "npm run lint",
-    "debug": "node debug.js"
+    "version": "node version.js && git add ./lib/preload/ndb/preload.js"
   },
   "author": "The Chromium Authors",
   "license": "Apache-2.0",

--- a/services/ndd_service.js
+++ b/services/ndd_service.js
@@ -14,8 +14,6 @@ const caughtErrorDebug = require('debug', 'ndd_service:caught');
 const { rpc, rpc_process } = require('carlo/rpc');
 const WebSocket = require('ws');
 
-const NDB_VERSION = require('../package.json').version;
-
 function silentRpcErrors(error) {
   if (!process.connected && error.code === 'ERR_IPC_CHANNEL_CLOSED')
     return;
@@ -137,10 +135,9 @@ class NddService {
 
   env() {
     return {
-      NODE_OPTIONS: `--require ndb/preload.js --inspect=0`,
+      NODE_OPTIONS: `--require ndb/preload.js`,
       NODE_PATH: `${process.env.NODE_PATH || ''}${path.delimiter}${path.join(__dirname, '..', 'lib', 'preload')}`,
-      NDD_IPC: this._pipe,
-      NDB_VERSION
+      NDD_IPC: this._pipe
     };
   }
 

--- a/services/terminal.js
+++ b/services/terminal.js
@@ -5,7 +5,6 @@
  */
 
 const fs = require('fs');
-const path = require('path');
 const { rpc, rpc_process } = require('carlo/rpc');
 
 class Terminal {
@@ -14,11 +13,6 @@ class Terminal {
     let shell = process.env.SHELL;
     if (!shell || !fs.existsSync(shell))
       shell = process.platform === 'win32' ? 'cmd.exe' : 'bash';
-    const NDB_VERSION = require('../package.json').version;
-    let nodePath = process.env.NODE_PATH || '';
-    if (nodePath)
-      nodePath += process.platform === 'win32' ? ';' : ':';
-    nodePath += path.join(__dirname, '..', 'lib', 'preload');
     this._term = pty.spawn(shell, [], {
       name: 'xterm-color',
       cols: cols,

--- a/version.js
+++ b/version.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+
+(function main() {
+  const version = require('./package.json').version;
+  let preload = fs.readFileSync('./lib/preload/ndb/preload.js', 'utf8');
+  preload = preload.replace(/process\.versions\['ndb'\] = '[\d+\.]+';/, `process.versions['ndb'] = '${version}';`);
+  fs.writeFileSync('./lib/preload/ndb/preload.js', preload, 'utf8');
+})();


### PR DESCRIPTION
As less environment variable we pass around as easier it to run
a little script to allow external node instances to connect to ndb.

drive-by: inspector.open to start inspector instead of passing
 --inspect flag.