### PR TITLE
fix(frontend): substitute node and npm with full paths

### DIFF
--- a/front_end/ndb/NdbMain.js
+++ b/front_end/ndb/NdbMain.js
@@ -10,6 +10,12 @@ Ndb.nodeExecPath = function() {
   return Ndb._nodeExecPathPromise;
 };
 
+Ndb.npmExecPath = function() {
+  if (!Ndb._npmExecPathPromise)
+    Ndb._npmExecPathPromise = Ndb.backend.which('npm').then(result => result.resolvedPath);
+  return Ndb._npmExecPathPromise;
+};
+
 Ndb.processInfo = function() {
   if (!Ndb._processInfoPromise)
     Ndb._processInfoPromise = Ndb.backend.processInfo();
@@ -107,6 +113,10 @@ Ndb.mainConfiguration = async() => {
     execPath = cmd[0];
     args = cmd.slice(1);
   }
+  if (execPath === 'npm')
+    execPath = await Ndb.npmExecPath();
+  else if (execPath === 'node')
+    execPath = await Ndb.nodeExecPath();
   return {
     name: 'main',
     command: cmd.join(' '),

--- a/front_end/ndb_ui/RunConfiguration.js
+++ b/front_end/ndb_ui/RunConfiguration.js
@@ -10,7 +10,6 @@ Ndb.RunConfiguration = class extends UI.VBox {
     this.registerRequiredCSS('ndb_ui/runConfiguration.css');
     this._items = new UI.ListModel();
     this._list = new UI.ListControl(this._items, this, UI.ListMode.NonViewport);
-    this._npmExecPathPromise = null;
     this.contentElement.appendChild(this._list.element);
     this.update();
   }
@@ -29,12 +28,6 @@ Ndb.RunConfiguration = class extends UI.VBox {
         args: ['run', name]
       }))));
     }
-  }
-
-  _npmExecPath() {
-    if (!this._npmExecPathPromise)
-      this._npmExecPathPromise = Ndb.backend.which('npm').then(result => result.resolvedPath);
-    return this._npmExecPathPromise;
   }
 
   /**
@@ -66,11 +59,11 @@ Ndb.RunConfiguration = class extends UI.VBox {
   }
 
   async _runConfig(execPath, args) {
-    await Ndb.nodeProcessManager.debug(execPath || await this._npmExecPath(), args);
+    await Ndb.nodeProcessManager.debug(execPath || await Ndb.npmExecPath(), args);
   }
 
   async _profileConfig(execPath, args) {
-    await Ndb.nodeProcessManager.profile(execPath || await this._npmExecPath(), args);
+    await Ndb.nodeProcessManager.profile(execPath || await Ndb.npmExecPath(), args);
   }
 
   /**


### PR DESCRIPTION
Sometimes windows can not resolve path to npm, full path should be
more reliable.

Partially fixes https://github.com/GoogleChromeLabs/ndb/issues/164