### PR TITLE
fix(backend): report file urls for file system

### DIFF
--- a/services/file_system.js
+++ b/services/file_system.js
@@ -1,7 +1,20 @@
 const fs = require('fs');
+const url = require('url');
 
 const { rpc, rpc_process } = require('carlo/rpc');
 const chokidar = require('chokidar');
+
+let pathToUrl;
+if (!url.pathToFileURL) {
+  // Node 8 does not convert file paths to file urls, so we do not need to
+  // polyfill pathToUrl here.
+  pathToUrl = str => str;
+} else {
+  pathToUrl = function(fileName) {
+    if (url.pathToFileURL)
+      return url.pathToFileURL(fileName).toString();
+  };
+}
 
 class FileSystemHandler {
   constructor() {
@@ -26,7 +39,7 @@ class FileSystemHandler {
           setTimeout(() => client.filesChanged(events.splice(0)), 100);
         events.push({
           type: event,
-          name: name
+          name: pathToUrl(name)
         });
       }
     });
@@ -35,7 +48,7 @@ class FileSystemHandler {
 
   forceFileLoad(fileName) {
     if (fileName.startsWith(this._embedderPath) && fs.existsSync(fileName))
-      this._client.filesChanged([{type: 'add', name: fileName}]);
+      this._client.filesChanged([{type: 'add', name: pathToUrl(fileName)}]);
   }
 
   dispose() {


### PR DESCRIPTION
Starting with v10, Node uses file urls in inspector protocol.
Breakpoints work iff file path is reported using file url.
Otherwise provisional breakpoint will use path with spaces,
instead of %20.

Bug: https://github.com/GoogleChromeLabs/ndb/issues/204