### PR TITLE
fix(frontend): report image file content as base64

### DIFF
--- a/front_end/ndb/FileSystem.js
+++ b/front_end/ndb/FileSystem.js
@@ -96,8 +96,12 @@ Ndb.FileSystem = class extends Persistence.PlatformFileSystem {
    */
   async requestFileContent(path, callback) {
     const result = await this._fsIOService.readFile(this._rootURL + path, 'base64');
-    const content = await(await fetch(`data:application/octet-stream;base64,${result}`)).text();
-    callback(content, false);
+    if (this.contentType(path) === Common.resourceTypes.Image) {
+      callback(result, true);
+    } else {
+      const content = await(await fetch(`data:application/octet-stream;base64,${result}`)).text();
+      callback(content, false);
+    }
   }
 
   /**


### PR DESCRIPTION
Image should be reported using base64 encoding.