### PR TITLE
fix(frontend): frontend uses file urls instead of paths

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -16,6 +16,7 @@ const querystring = require('querystring');
 const which = require('which');
 
 const fsReadFile = util.promisify(fs.readFile);
+const { fileURLToPath } = require('./filepath_to_url.js');
 
 const MODULE_WRAP_PREFIX = (() => {
   const wrapped = require('module').wrap('☃');
@@ -25,7 +26,7 @@ const MODULE_WRAP_PREFIX = (() => {
 class Backend {
   constructor(window) {
     this._window = window;
-    this._info = window.paramsForReuse();
+    this._info = JSON.parse(Buffer.from(window.paramsForReuse().data, 'base64').toString('utf8'));
     this._handles = [];
     this._window.on('close', () => this._handles.splice(0).forEach(handle => handle.dispose()));
   }
@@ -51,7 +52,7 @@ class Backend {
   pkg() {
     // TODO(ak239spb): implement it as decorations over package.json file.
     try {
-      return require(path.join(this._info.cwd, 'package.json'));
+      return require(path.join(fileURLToPath(this._info.cwd), 'package.json'));
     } catch (e) {
       return null;
     }
@@ -98,6 +99,10 @@ class Backend {
       process.stderr.write(buffer);
     else if (stream === 'stdout')
       process.stdout.write(buffer);
+  }
+
+  fileURLToPath(url) {
+    return fileURLToPath(url);
   }
 
   async loadNetworkResource(url, headers) {

--- a/lib/filepath_to_url.js
+++ b/lib/filepath_to_url.js
@@ -1,0 +1,36 @@
+const url = require('url');
+
+if (url.pathToFileURL) {
+  module.exports = {
+    pathToFileURL: url.pathToFileURL,
+    fileURLToPath: url.fileURLToPath
+  };
+} else {
+  // Node 8 does not have nice url methods.
+  // Polyfill should match DevTools frontend behavior,
+  // otherwise breakpoints will not work.
+  function pathToFileURL(fileSystemPath) {
+    fileSystemPath = fileSystemPath.replace(/\\/g, '/');
+    if (!fileSystemPath.startsWith('file://')) {
+      if (fileSystemPath.startsWith('/'))
+        fileSystemPath = 'file://' + fileSystemPath;
+      else
+        fileSystemPath = 'file:///' + fileSystemPath;
+    }
+    return fileSystemPath;
+  }
+  /**
+   * @param {string} fileURL
+   * @return {string}
+   */
+  function fileURLToPath(fileURL) {
+    if (process.platform === 'win32')
+      return fileURL.substr('file:///'.length).replace(/\//g, '\\');
+    return fileURL.substr('file://'.length);
+  }
+
+  module.exports = {
+    fileURLToPath,
+    pathToFileURL,
+  };
+}

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -7,7 +7,7 @@
 const path = require('path');
 const carlo = require('carlo');
 const { rpc, rpc_process } = require('carlo/rpc');
-
+const { pathToFileURL } = require('./filepath_to_url.js');
 const { Backend } = require('./backend.js');
 
 process.on('unhandledRejection', error => {
@@ -23,8 +23,11 @@ async function launch() {
       bgcolor: '#242424',
       channel: ['chromium'],
       paramsForReuse: {
-        cwd: process.cwd(),
-        argv: process.argv
+        data: Buffer.from(JSON.stringify({
+          cwd: pathToFileURL(process.cwd()).toString(),
+          argv: process.argv,
+          nodeExecPath: process.execPath
+        })).toString('base64')
       }
     });
   } catch (e) {

--- a/lib/preload/ndb/preload.js
+++ b/lib/preload/ndb/preload.js
@@ -14,9 +14,10 @@
     } catch (e) {
       // node 8 does not support workers
     }
+    const { pathToFileURL } = require('../../filepath_to_url.js');
     let scriptName = '';
     try {
-      scriptName = require.resolve(process.argv[1]);
+      scriptName = pathToFileURL(require.resolve(process.argv[1])).toString();
     } catch (e) {
       // preload can get scriptName iff node starts with script as first argument,
       // we should be ready for exception in other cases, e.g., node -e '...'
@@ -29,7 +30,7 @@
     const inspector = require('inspector');
     inspector.open(0, undefined, false);
     const info = {
-      cwd: process.cwd(),
+      cwd: pathToFileURL(process.cwd()),
       argv: process.argv.concat(process.execArgv),
       data: process.env.NDD_DATA,
       ppid: ppid,

--- a/services/ndd_service.js
+++ b/services/ndd_service.js
@@ -8,6 +8,7 @@ const { spawn } = require('child_process');
 const os = require('os');
 const path = require('path');
 const net = require('net');
+const { fileURLToPath } = require('../lib/filepath_to_url.js');
 
 const protocolDebug = require('debug')('ndd_service:protocol');
 const caughtErrorDebug = require('debug', 'ndd_service:caught');
@@ -146,7 +147,7 @@ class NddService {
     if (options.data)
       env.NDD_DATA = options.data;
     const p = spawn(execPath, args, {
-      cwd: options.cwd,
+      cwd: options.cwd ? fileURLToPath(options.cwd) : undefined,
       env: { ...process.env, ...env },
       stdio: options.ignoreOutput ? 'ignore' : ['inherit', 'pipe', 'pipe'],
       windowsHide: true

--- a/services/search.js
+++ b/services/search.js
@@ -8,6 +8,8 @@ const { rpc, rpc_process } = require('carlo/rpc');
 const fs = require('fs');
 const path = require('path');
 
+const { fileURLToPath, pathToFileURL } = require('../lib/filepath_to_url.js');
+
 const isbinaryfile = require('isbinaryfile');
 
 // TODO(ak239): track changed files.
@@ -30,6 +32,7 @@ class SearchBackend {
    * @param {string} fileSystemPath
    */
   async indexPath(requestId, fileSystemPath, excludedPattern) {
+    fileSystemPath = fileURLToPath(fileSystemPath);
     const excludeRegex = new RegExp(excludedPattern);
     if (this._index.has(fileSystemPath)) {
       this._indexChangedFiles(requestId, fileSystemPath);
@@ -185,6 +188,7 @@ class SearchBackend {
    * @param {string} query
    */
   searchInPath(requestId, fileSystemPath, query) {
+    fileSystemPath = fileURLToPath(fileSystemPath);
     const index = this._index.get(fileSystemPath);
     let result = [];
     query = query.toLowerCase();
@@ -205,6 +209,7 @@ class SearchBackend {
       result = Array.from(resultSet);
     }
     result = result.map(index => this._indexToFileName.get(index));
+    result = result.map(result => pathToFileURL(result).toString());
     this._frontend.searchCompleted(requestId, fileSystemPath, result);
   }
 


### PR DESCRIPTION
FileSystem works only with file urls.
All breakpoints are set by path and by url.

Frontend gets only file urls from ndb backend and passes only file
urls to backend. There is only one exception - 'Run this script'
frontend action convert script file url to path on frontend side.

Over the protocol any url is always returned as file urls (frontend
patches messages from Node 8). Debugger.setBreakpointByUrl replaces
url with regex pattern: path|url to work with Node 8 and later Nodes.

https://github.com/GoogleChromeLabs/ndb/issues/204