### PR TITLE
fix(NddService): fix NddService socket.on('data') for large input

### DIFF
--- a/services/ndd_service.js
+++ b/services/ndd_service.js
@@ -95,8 +95,13 @@ class NddService {
     const pipeName = `node-ndb.${process.pid}.sock`;
     this._pipe = path.join(pipePrefix, pipeName);
     const server = net.createServer(socket => {
+      const chunks = [];
       socket.on('data', async d => {
-        const runSession = await this._startSession(JSON.parse(d), frontend);
+        chunks.push(d);
+      });
+      socket.on('end', async() => {
+        const data = Buffer.concat(chunks);
+        const runSession = await this._startSession(JSON.parse(data), frontend);
         socket.write('run');
         runSession();
       });


### PR DESCRIPTION
This patch fixes NddService.server socker.on('data') so that it can handle large amounts of input without throwing `SyntaxError: Unexpected end of JSON input` errors.

Fixes #319