### PR TITLE
Fixed Broken Image Url - Chrome Devtools Logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![NPM ndb package](https://img.shields.io/npm/v/ndb.svg)](https://npmjs.org/package/ndb)
 <!-- [END badges] -->
 
-<img src="https://raw.githubusercontent.com/ChromeDevTools/devtools-logo/master/192.png" height="200" align="right">
+<img src="https://github.com/ChromeDevTools/devtools-logo/blob/master/logos/svg/chrome-devtools-square.svg" align="right" width="200" height="200" alt="DevTools logo">
 
 > ndb is an improved debugging experience for Node.js, enabled by Chrome DevTools
 


### PR DESCRIPTION
### Proposed Changes

Image url was pointing to 404 status resource. I went to official [ChromeDevTools repository](https://github.com/ChromeDevTools/devtools-logo), referred to the `svg` logo present in [README.md](https://github.com/ChromeDevTools/devtools-logo/blob/master/README.md) and made the correction to `README.md` file of this repository.

> Ensured rest of the attributes: `align="right"` and `height="200"` stays the same.

### Screenshot

![ChromeDevtools Logo](https://user-images.githubusercontent.com/25281055/170436053-5f22fbb9-603f-4187-8a70-14ddc66f5dea.png)

